### PR TITLE
Fix versioned docs to show full version-history dropdown

### DIFF
--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -44,21 +44,39 @@ jobs:
               config['metadata'] = {}
           config['metadata']['version'] = version
 
-          # Update navbar: set version text and rebuild version menu
+          # Update navbar: set version text and mark this version "current" in the
+          # menu, keeping every other entry (dev + prior releases) already committed
+          # in _quarto.yml -- rather than replacing the whole menu with just
+          # [this version, dev], which is all the previous version of this script
+          # did (every versioned page only ever knew about itself + dev, never any
+          # sibling releases). Self-healing: if this version isn't in the list yet
+          # (the normal case -- the dev-docs entry for a new version is usually
+          # added *after* the release build, per _quarto.yml's own instructions),
+          # it's inserted rather than skipped.
+          current_href = f'{base_url}/{version}/docs/index.html'
           navbar = config.get('website', {}).get('navbar', {})
           right_items = navbar.get('right', [])
           for item in right_items:
               if isinstance(item, dict) and 'menu' in item:
+                  order = []
+                  text_by_href = {}
+                  for entry in item.get('menu', []):
+                      href = entry['href']
+                      text = entry['text'].replace(' (current)', '')
+                      if href not in text_by_href:
+                          order.append(href)
+                      text_by_href[href] = text
+                  text_by_href[current_href] = version
+                  if current_href not in order:
+                      order.append(current_href)
+
                   item['text'] = f"Version: {version}"
                   item['menu'] = [
                       {
-                          'text': f'{version} (current)',
-                          'href': f'{base_url}/{version}/docs/index.html'
-                      },
-                      {
-                          'text': 'dev',
-                          'href': f'{base_url}/dev/docs/index.html'
+                          'text': f'{version} (current)' if href == current_href else text_by_href[href],
+                          'href': href,
                       }
+                      for href in [current_href] + [h for h in order if h != current_href]
                   ]
 
           with open('_quarto.yml', 'w') as f:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,13 +22,17 @@ website:
     right:
       - text: "Docs"
         href: docs/index.md
-      # Version menu shown on the DEV docs site. docs-release.yml patches its own
-      # ephemeral copy of this file during a release build to render that one
-      # version's page (showing just "{version} (current)" + "dev") -- that patch
-      # is never committed back to any branch, so it does NOT keep this list here
-      # in sync. After every tagged release, manually add a "{version}" entry
-      # below (newest first, right after "dev (current)") so the dev docs site's
-      # dropdown links to it.
+      # Version menu shown on the DEV docs site. This committed list is also the
+      # source docs-release.yml's "Patch _quarto.yml for release" step starts from
+      # when it builds a tagged release's own ephemeral copy -- it marks the
+      # version being tagged as "(current)" (inserting it if not already present
+      # here) and otherwise keeps every entry below as-is, so a versioned page
+      # shows the same full history this list does at the time it's built. That
+      # patch is never committed back to any branch, though, so THIS list (the one
+      # the dev docs site actually renders) still needs a manual "{version}" entry
+      # added below after every tagged release -- otherwise the dev docs dropdown
+      # itself won't link to the new version (older already-built versioned pages
+      # are frozen snapshots and can't pick up later additions either way).
       - text: "Version: dev"
         menu:
           - text: "dev (current)"


### PR DESCRIPTION
## Summary
- Every released docs page (e.g. `2.0.0/docs/index.html`) only ever showed itself + `dev` in the version dropdown -- never any sibling release -- because `docs-release.yml`'s release-build patch step wholesale-replaced the navbar menu with exactly those two entries, discarding whatever else was already in `_quarto.yml`.
- The patch step now merges into the existing committed menu instead: marks the version being tagged as "(current)" (self-healing -- inserts it if not already listed), keeps every other entry (dev + prior releases) as-is.
- Forward-looking only -- doesn't retroactively change already-built versioned pages (2.0.0, 1.2.1), which stay frozen snapshots of `_quarto.yml` at tag time.

## Test plan
- [x] Extracted the embedded Python patch script and ran it standalone against the real `_quarto.yml`, for both a version already in the list (`2.0.0`) and a brand-new one (`2.1.0`) -- both produced the expected merged, ordered menu (current first, then the rest unchanged).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow YAML is well-formed.
- [x] Real end-to-end confirmation happens on the next actual tag push.

⚡ generated by AI ⚡